### PR TITLE
feat: extend jwt payload with user data

### DIFF
--- a/settings.schema.yaml
+++ b/settings.schema.yaml
@@ -1,4 +1,4 @@
-$schema: https://json-schema.org/draft-07/schema#
+$schema: https://json-schema.org/draft-07/schema
 $defs:
   Authentication:
     additionalProperties: false
@@ -47,11 +47,12 @@ $defs:
     type: string
   InNoHassleAccounts:
     additionalProperties: false
-    description: Use production InNoHassle-Accounts API for authentication in local
+    description: Use production InNoHassle Accounts API for authentication in local
       development
     properties:
       api_url:
-        description: API URL for InNoHassle-Accounts
+        default: https://api.innohassle.ru/accounts/v0
+        description: API URL for InNoHassle Accounts
         title: Api Url
         type: string
       api_jwt_token:
@@ -61,7 +62,6 @@ $defs:
         type: string
         writeOnly: true
     required:
-    - api_url
     - api_jwt_token
     title: InNoHassleAccounts
     type: object

--- a/src/modules/tokens/repository.py
+++ b/src/modules/tokens/repository.py
@@ -1,13 +1,14 @@
 __all__ = ["TokenRepository"]
 
 from datetime import datetime, timedelta
-from typing import Any
+from typing import Any, Dict
 
 from authlib.jose import JsonWebKey, jwt
 from beanie import PydanticObjectId
-from src.storages.mongo.models import User
+
 from src.config import settings
-from typing import Dict, Optional
+from src.storages.mongo.models import User
+
 
 class TokenRepository:
     ALGORITHM = "RS256"
@@ -28,7 +29,7 @@ class TokenRepository:
         return str(encoded_jwt, "utf-8")
 
     @classmethod
-    def _add_user_payload(cls, user: User, data: Dict[str,Any] = {}) -> Dict[str, Any]:
+    def _add_user_payload(cls, user: User, data: Dict[str, Any] = {}) -> Dict[str, Any]:
         if user.innopolis_sso:
             data.update({"email": user.innopolis_sso.email})
         if user.telegram:
@@ -43,10 +44,7 @@ class TokenRepository:
 
     @classmethod
     def create_user_access_token(cls, user: User) -> str:
-        data =  TokenRepository._add_user_payload(
-            user,
-            data={"uid": str(user.id)}
-        )
+        data = TokenRepository._add_user_payload(user, data={"uid": str(user.id)})
         access_token = TokenRepository._create_token(data=data, expires_delta=timedelta(days=1), scopes=["me"])
         return access_token
 

--- a/src/modules/tokens/repository.py
+++ b/src/modules/tokens/repository.py
@@ -1,7 +1,7 @@
 __all__ = ["TokenRepository"]
 
 from datetime import datetime, timedelta
-from typing import Any, Dict
+from typing import Any
 
 from authlib.jose import JsonWebKey, jwt
 from beanie import PydanticObjectId
@@ -29,7 +29,7 @@ class TokenRepository:
         return str(encoded_jwt, "utf-8")
 
     @classmethod
-    def _add_user_payload(cls, user: User, data: Dict[str, Any] = {}) -> Dict[str, Any]:
+    def _add_user_payload(cls, user: User, data: dict = {}) -> dict:
         if user.innopolis_sso:
             data.update({"email": user.innopolis_sso.email})
         if user.telegram:

--- a/src/modules/tokens/routes.py
+++ b/src/modules/tokens/routes.py
@@ -36,7 +36,7 @@ async def generate_my_token(user: UserDep) -> TokenData:
     """
     Generate access token for current user with user id in `uid` field
     """
-    token = TokenRepository.create_user_access_token(user.id)
+    token = TokenRepository.create_user_access_token(user)
     return TokenData(access_token=token)
 
 


### PR DESCRIPTION
### Description
Add optional user data fields for `/tokens/generate-my-token` endpoint.

### JWT Payload extension
```python
{
    ...,
    # if User has innopolis_sso data
    "email":  str = User.innopolis_sso.email,
    # if User has telegram data
    "telegram_id": int = user.telegram.id
}
```
Fixes [#56](https://github.com/one-zero-eight/accounts/issues/56)
