### PR TITLE
Feat/avatar proxy

### DIFF
--- a/settings.example.yaml
+++ b/settings.example.yaml
@@ -21,6 +21,7 @@ auth:
 mongo:
   uri: mongodb://mongoadmin:secret@localhost:27017/db?authSource=admin
 telegram: null
+proxy_url: null
 accounts:
   # Get from https://api.innohassle.ru/accounts/v0/tokens/generate-service-token?sub=accounts-local-dev&scopes=users&only_for_me=true
   api_jwt_token: null

--- a/settings.schema.yaml
+++ b/settings.schema.yaml
@@ -172,6 +172,13 @@ properties:
     - type: 'null'
     default: null
     description: Telegram settings
+  proxy_url:
+    anyOf:
+    - type: string
+    - type: 'null'
+    default: null
+    description: Proxy for telegram
+    title: Proxy Url
   accounts:
     anyOf:
     - $ref: '#/$defs/Accounts'

--- a/src/api/lifespan.py
+++ b/src/api/lifespan.py
@@ -3,6 +3,7 @@ __all__ = ["lifespan"]
 import asyncio
 from contextlib import asynccontextmanager
 
+import httpx
 from beanie import init_beanie
 from fastapi import FastAPI
 from motor.motor_asyncio import AsyncIOMotorClient
@@ -51,15 +52,24 @@ async def setup_repositories() -> AsyncIOMotorClient:
 
 
 @asynccontextmanager
-async def lifespan(_app: FastAPI):
+async def lifespan(app: FastAPI):
     # Application startup
 
     motor_client = await setup_repositories()
 
     # Start daily loop update telegram info
     daily_task = asyncio.create_task(daily_loop_update_telegram_info())
+    if settings.proxy_url:
+        transport = httpx.AsyncHTTPTransport(proxy=settings.proxy_url)
+    else:
+        transport = None
+
+    client = httpx.AsyncClient(transport=transport, timeout=8.0, follow_redirects=True)
+    app.state.client = client
 
     yield
+
+    await client.aclose()
 
     # Application shutdown
     daily_task.cancel()

--- a/src/config_schema.py
+++ b/src/config_schema.py
@@ -81,6 +81,8 @@ class Settings(SettingsEntityModel):
     "Innopolis SSO settings (only for production)"
     telegram: Telegram | None = None
     "Telegram settings"
+    proxy_url: str | None = None
+    "Proxy for telegram"
     accounts: Accounts | None = None
     "Use production InNoHassle Accounts API for authentication in local development"
 

--- a/src/modules/users/routes.py
+++ b/src/modules/users/routes.py
@@ -4,8 +4,9 @@ User data and linking users with event groups.
 
 from typing import Annotated, Any
 
+import httpx
 from beanie import PydanticObjectId
-from fastapi import APIRouter, Body, Query, Request, Security
+from fastapi import APIRouter, Body, Query, Request, Response, Security
 
 from src.api import docs
 from src.api.dependencies import AdminDep, UserIdDep
@@ -35,6 +36,50 @@ async def get_me(user_id: UserIdDep, request: Request) -> ViewUser:
         request.session.clear()
         raise UserWithoutSessionException()
     return view_from_user(user)
+
+
+@router.get(
+    "/me/avatar.jpg",
+    responses={
+        200: {"description": "Avatar for the current user", "content": {"image/*": {}}},
+        **UserWithoutSessionException.responses,
+        **ObjectNotFound.responses,
+    },
+)
+async def get_avatar(user_id: UserIdDep, request: Request) -> Response:
+    """
+    Get current user's Telegram avatar. We proxy the request through our server
+    because Telegram CDN URLs may be blocked in some networks.
+    """
+    user = await user_repository.read(user_id)
+    if user is None:
+        # clear session cookie if user is not found
+        request.session.clear()
+        raise UserWithoutSessionException()
+
+    if not user.telegram or not user.telegram.photo_url:
+        raise ObjectNotFound("User has no photo")
+
+    client = request.app.state.client
+
+    try:
+        response = await client.get(user.telegram.photo_url)
+    except httpx.HTTPError:
+        raise ObjectNotFound("Failed to fetch avatar")
+
+    if response.status_code != 200:
+        raise ObjectNotFound("Avatar not available")
+
+    content_type = response.headers.get("content-type", "")
+    content_type = content_type.split(";")[0].strip()
+    if not content_type.startswith("image/"):
+        content_type = "image/jpeg"
+
+    return Response(
+        content=response.content,
+        media_type=content_type,
+        headers={"Cache-Control": "private, max-age=300"},
+    )
 
 
 SUGGEST_ON_TYPING_LIMIT = 10


### PR DESCRIPTION
This pull request introduces support for proxying Telegram requests through a configurable proxy, and adds a new endpoint to serve user Telegram avatars via the backend. This helps users access Telegram-hosted images even in networks where Telegram is blocked, and centralizes HTTP client configuration with proxy support.

**Proxy support and HTTP client improvements:**

* Added a new `proxy_url` setting to the configuration files (`settings.example.yaml`, `settings.schema.yaml`, `src/config_schema.py`) to allow specifying a proxy for Telegram requests. [[1]](diffhunk://#diff-a5e688edb24b7a554d83e0348662c57081a960e6acc6d1c47eb265240ffdbd43R24) [[2]](diffhunk://#diff-0d180296e59b56f78b34c5f00aeccaf93b24231bf0d6160d2edaed103f9d4c6fR175-R181) [[3]](diffhunk://#diff-8d5f1bfb68daefffdc0ae5f4c17e4da181868a59cfeb3b4613d42a18e0666330R84-R85)
* Updated the application lifespan (`src/api/lifespan.py`) to initialize a shared `httpx.AsyncClient` with optional proxy support, and store it in `app.state.client` for use throughout the app. The client is properly closed on shutdown. [[1]](diffhunk://#diff-76faac66dbb870576c5e921df9ecabbab1c180f1e2e95824394f60380075bb52R6) [[2]](diffhunk://#diff-76faac66dbb870576c5e921df9ecabbab1c180f1e2e95824394f60380075bb52L54-R73)

**New API endpoint:**

* Added a `/me/avatar.jpg` endpoint in `src/modules/users/routes.py` that fetches the current user's Telegram avatar, proxying the request through the backend using the shared HTTP client. This ensures avatars are accessible even if Telegram CDN URLs are blocked, and provides caching headers. [[1]](diffhunk://#diff-143f5ba3456b5e9834db8d5a6c6cb95ddd3acca13b0dd69eec034fcb6e26f078R7-R9) [[2]](diffhunk://#diff-143f5ba3456b5e9834db8d5a6c6cb95ddd3acca13b0dd69eec034fcb6e26f078R41-R84)### Description of changes

closes #85 
